### PR TITLE
Updated sales funnel to account for free payment gateway.

### DIFF
--- a/src/presenters/SalesFunnelPresenter.php
+++ b/src/presenters/SalesFunnelPresenter.php
@@ -115,6 +115,7 @@ class SalesFunnelPresenter extends FrontendPresenter
 
         $this->template->payment = $payment;
         $this->template->subscription = $payment->subscription;
+        $this->template->destination = $this->paymentMetaRepository->values($payment, 'destination')->fetch()->value;
 
         // removing session created in SalesFunnelFrontendPresenter
         $this->getSession('sales_funnel')->remove();

--- a/src/templates/SalesFunnel/success.latte
+++ b/src/templates/SalesFunnel/success.latte
@@ -42,6 +42,7 @@
 
             <div id="finish">
                 {control simpleWidget 'frontend.payment.success.finish_registration', $payment}
+        		<a n:if="$destination" class="btn btn-primary" href="{$destination}">Back to article</a>
             </div>
         </div>
     </div>

--- a/src/templates/SalesFunnelFrontend/success.latte
+++ b/src/templates/SalesFunnelFrontend/success.latte
@@ -1,0 +1,15 @@
+{block title}Success{/block}
+
+{block #headstart}{/block}
+
+{block #content}
+
+  <div class="container">
+      <h1>Thank you for your subscription.</h1>
+
+      <div class="row">
+          <a href="{$destination}" class="btn btn-primary">Return to post</a>
+      </div>
+  </div>
+
+{/block}


### PR DESCRIPTION
I have modified the SaelsFunnelFrontendPresenter class:
- to Show only the free payment gateway, if one is available for the funnel.
- to skip the payment creation if the payment gateway is 'free', it will create a subscription right away, and display a thankyou page with a link back to the article if a destination url parameter is given.
- to save a destination to the payment meta data, when the payment gateway is other than 'free', so it can be displayed on the payment success page.

The SalesFunnelPresenter success template has been updated to display link back to the article the user came from.
The SalesFunnelFrontePresenter success template has been added for Free payment success.